### PR TITLE
Feat/identificadores eiki

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -11,15 +11,18 @@ void yyerror(const char *s);    //usado quando há um erro
 %union {
     int intValue;
     float floatValue;
+    char *str;
 }
 
 /* Token que carrega valor semântico */
 %token <intValue> NUM
 %token <floatValue> NUMFLOAT
+%token <str> ID
 
 /* Tokens sem valor semântico, mas com precedência */
 %token PLUS MINUS TIMES DIVIDE LPAREN RPAREN
 %token COMPARATION EQUAL
+%token SEMICOLON LBRACE RBRACE LESS_EQUAL GREATER_EQUAL NOT_EQUAL LOGICAL_AND LOGICAL_OR
 /* Declara precedência:
    - PLUS e MINUS têm menor precedência
    - TIMES e DIVIDE têm maior precedência */
@@ -45,7 +48,8 @@ expr:
     | expr DIVIDE expr  { $$ = $1 / $3; }
     | LPAREN expr RPAREN{ $$ = $2; }
     | NUM               { $$ = $1; }
-    | NUMFLOAT             { $$ = $1; }
+    | NUMFLOAT          { $$ = $1; }
+    | ID                { free($1); $$ = 0; }
     ;
 
 %%

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2,6 +2,7 @@
 /* arquivo léxico do interpretador*/
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "parser.tab.h"  /* contém definições geradas pelo Bison (NUM, PLUS, etc.) */
 %}
 
@@ -78,6 +79,11 @@ while       { printf("KW_WHILE\n"); }
 "//".*     { /* Ignorar comentários de linha */ }
 
 "/*"([^*]|\*+[^*/])*\*+\/    { /* Ignorar comentários de bloco */ }
+
+[a-zA-Z_][a-zA-Z0-9_]* {
+    yylval.str = strdup(yytext);
+    return ID;
+}
 
 
 [0-9]+\.[0-9]+  { 


### PR DESCRIPTION
**O que foi feito na Task 1 (identificadores no scanner):**
Adicionado header necessário para strdup em scanner.l: L5.
Adicionada a regra de identificadores em scanner.l: L83.
A regra agora retorna o token ID em scanner.l: L85, carregando o lexema em yylval.str.

**O que foi feito na Task 2 (tokens relacionados no parser):**
Incluído campo semântico para string no union em parser.y: L14.
Declarado o token relacionado ao identificador em parser.y: L20.
Declarados tokens adicionais já usados pelo scanner para manter compatibilidade de header em parser.y: L25.
Incluído uso de ID na gramática com liberação de memória em parser.y: L52.
