### PR TITLE
Fix/correcoes semanticas

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -16,6 +16,13 @@ static ASTNode *alloc_node() {
     return n;
 }
 
+ASTNode *set_node_line(ASTNode *node, int line) {
+    if (node) {
+        node->line = line;
+    }
+    return node;
+}
+
 static void print_indent(int indent) {
     for (int i = 0; i < indent; i++)
         printf("  ");
@@ -121,6 +128,7 @@ ASTNode *new_block(ASTNode *statement, ASTNode *next) {
     ASTNode *n = alloc_node();
 
     n->type = NODE_BLOCK;
+    n->line = statement ? statement->line : 0;
 
     n->block.statement = statement;
     n->block.next = next;
@@ -152,7 +160,16 @@ ASTNode *new_assign(char *name, ASTNode *val) {
     ASTNode *n = alloc_node();
     n->type = NODE_ASSIGN;
     n->assign.name = name; 
+    n->assign.decl_type = NULL;
+    n->assign.is_declaration = 0;
     n->assign.value = val;
+    return n;
+}
+
+ASTNode *new_declaration(char *type, char *name, ASTNode *val) {
+    ASTNode *n = new_assign(name, val);
+    n->assign.decl_type = type;
+    n->assign.is_declaration = 1;
     return n;
 }
 
@@ -242,7 +259,13 @@ void print_ast(ASTNode *node, int indent) {
             break;
 
         case NODE_ASSIGN:
-            printf("ASSIGN(%s)\n", node->assign.name);
+            if (node->assign.is_declaration) {
+                printf("DECL(%s %s)\n",
+                       node->assign.decl_type ? node->assign.decl_type : "?",
+                       node->assign.name);
+            } else {
+                printf("ASSIGN(%s)\n", node->assign.name);
+            }
 
             print_indent(indent + 1);
             printf("VALUE:\n");
@@ -402,6 +425,7 @@ void free_ast(ASTNode *node) {
 
         case NODE_ASSIGN:
             free(node->assign.name);
+            free(node->assign.decl_type);
             free_ast(node->assign.value);
             break;
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -31,6 +31,7 @@ typedef enum {
 
 typedef struct ASTNode {
     NodeType type;
+    int line;
     union {
         double num_val;         // número
         char  *var_name;        // variável
@@ -60,6 +61,8 @@ typedef struct ASTNode {
 
         struct {                // atribuição
             char *name;
+            char *decl_type;
+            int is_declaration;
             struct ASTNode *value;
         } assign;
 
@@ -78,9 +81,11 @@ ASTNode *new_while(ASTNode *cond, ASTNode *body);
 ASTNode *new_block(ASTNode *statement, ASTNode *next);
 ASTNode *append_block(ASTNode *block, ASTNode *statement);
 ASTNode *new_assign(char *name, ASTNode *val);
+ASTNode *new_declaration(char *type, char *name, ASTNode *val);
 ASTNode *new_string_literal(char *str);
 ASTNode *new_char_literal(char *ch);
 ASTNode *new_printf(ASTNode *expr);
+ASTNode *set_node_line(ASTNode *node, int line);
 
 // utilidades
 void print_ast(ASTNode *node, int indent);

--- a/src/parser.y
+++ b/src/parser.y
@@ -32,6 +32,7 @@ ASTNode *root = NULL;
 %}
 
 %define parse.error detailed
+%locations
 
 %nonassoc LOWER_THAN_ELSE
 %nonassoc ELSE_STATEMENT
@@ -53,11 +54,12 @@ ASTNode *root = NULL;
 %token <intValue> NUM
 %token <floatValue> NUMFLOAT
 %token <str> ID
+%token <str> TYPE_SPECIFIER
 %token <str> STRING_LITERAL
 %token <str> CHAR_LITERAL
 
 /* Tipos e Especificadores de Tipo */
-%token KW_BOOL BOOL_TYPE DOUBLE_TYPE KW_LONG KW_SIZE TYPE_MODIFIER TYPE_SPECIFIER KW_TYPE_MODIFIER
+%token KW_BOOL BOOL_TYPE DOUBLE_TYPE KW_LONG KW_SIZE TYPE_MODIFIER KW_TYPE_MODIFIER
 %token KW_DECIMAL32 KW_DECIMAL64 KW_DECIMAL128 KW_COMPLEX KW_IMAGINARY
 %token KW_TYPE_DECLARATION KW_DECLARATION_OF_A_COMPOUND_TYPE KW_DECLARATION_OF_A_UNION_TYPE ENUMERATION_TYPE
 %token KW_TYPE_OF_VARIABLE_OR_PARAMETER_OF_FUNCTION_OR_RETURN_VALUE
@@ -129,19 +131,19 @@ stmt_list
 stmt
     : IF_STATEMENT LPAREN expr RPAREN stmt ELSE_STATEMENT stmt
         {
-            $$ = new_if($3, $5, $7);
+            $$ = set_node_line(new_if($3, $5, $7), @1.first_line);
         }
 
 
     | IF_STATEMENT LPAREN expr RPAREN stmt %prec LOWER_THAN_ELSE
 
         {
-            $$ = new_if($3, $5, NULL);
+            $$ = set_node_line(new_if($3, $5, NULL), @1.first_line);
         }
 
     | KW_WHILE LPAREN expr RPAREN stmt
         {
-            $$ = new_while($3, $5);
+            $$ = set_node_line(new_while($3, $5), @1.first_line);
         }
 
     | LBRACE stmt_list RBRACE
@@ -152,23 +154,23 @@ stmt
     | TYPE_SPECIFIER ID EQUAL expr SEMICOLON
         {
             /* A tabela de símbolos não é mais populada aqui */
-            $$ = new_assign($2, $4);
+            $$ = set_node_line(new_declaration($1, $2, $4), @2.first_line);
         }
 
     | TYPE_SPECIFIER ID SEMICOLON
         {
-            $$ = new_assign($2, NULL);
+            $$ = set_node_line(new_declaration($1, $2, NULL), @2.first_line);
         }
 
     | ID EQUAL expr SEMICOLON
         {
             /* Validações semânticas removidas do parser */
-            $$ = new_assign($1, $3);
+            $$ = set_node_line(new_assign($1, $3), @1.first_line);
         }
 
     | KW_PRINTF LPAREN expr RPAREN SEMICOLON
         {
-            $$ = new_printf($3);
+            $$ = set_node_line(new_printf($3), @1.first_line);
         }
 
     | expr SEMICOLON
@@ -201,65 +203,65 @@ expr
     : expr PLUS expr
         {
             if (debug_mode) printf("Expr PLUS processada\n");
-            $$ = new_binop(OP_ADD, $1, $3);
+            $$ = set_node_line(new_binop(OP_ADD, $1, $3), @2.first_line);
         }
 
     | expr MINUS expr
         {
             if (debug_mode) printf("Expr MINUS processada\n");
-            $$ = new_binop(OP_SUB, $1, $3);
+            $$ = set_node_line(new_binop(OP_SUB, $1, $3), @2.first_line);
         }
 
     | expr TIMES expr
         {
             if (debug_mode) printf("Expr TIMES processada\n");
-            $$ = new_binop(OP_MUL, $1, $3);
+            $$ = set_node_line(new_binop(OP_MUL, $1, $3), @2.first_line);
         }
 
     | expr DIVIDE expr
         {
             if (debug_mode) printf("Expr DIVIDE processada\n");
-            $$ = new_binop(OP_DIV, $1, $3);
+            $$ = set_node_line(new_binop(OP_DIV, $1, $3), @2.first_line);
         }
 
     | expr LESS expr
         {
-            $$ = new_binop(OP_LT, $1, $3);
+            $$ = set_node_line(new_binop(OP_LT, $1, $3), @2.first_line);
         }
 
     | expr GREATER expr
         {
-            $$ = new_binop(OP_GT, $1, $3);
+            $$ = set_node_line(new_binop(OP_GT, $1, $3), @2.first_line);
         }
 
     | expr LESS_EQUAL expr
         {
-            $$ = new_binop(OP_LE, $1, $3);
+            $$ = set_node_line(new_binop(OP_LE, $1, $3), @2.first_line);
         }
 
     | expr GREATER_EQUAL expr
         {
-            $$ = new_binop(OP_GE, $1, $3);
+            $$ = set_node_line(new_binop(OP_GE, $1, $3), @2.first_line);
         }
 
     | expr COMPARATION expr
         {
-            $$ = new_binop(OP_EQ, $1, $3);
+            $$ = set_node_line(new_binop(OP_EQ, $1, $3), @2.first_line);
         }
 
     | expr NOT_EQUAL expr
         {
-            $$ = new_binop(OP_NEQ, $1, $3);
+            $$ = set_node_line(new_binop(OP_NEQ, $1, $3), @2.first_line);
         }
 
     | expr LOGICAL_AND expr
         {
-            $$ = new_binop(OP_AND, $1, $3);
+            $$ = set_node_line(new_binop(OP_AND, $1, $3), @2.first_line);
         }
 
     | expr LOGICAL_OR expr
         {
-            $$ = new_binop(OP_OR, $1, $3);
+            $$ = set_node_line(new_binop(OP_OR, $1, $3), @2.first_line);
         }
 
     | LPAREN expr RPAREN
@@ -271,40 +273,40 @@ expr
     | NUM
         {
             if (debug_mode) printf("Numero processado: %d\n", $1);
-            $$ = new_num($1);
+            $$ = set_node_line(new_num($1), @1.first_line);
         }
 
     | ID
         {
             if (debug_mode) printf("Identificador processado: %s\n", $1);
             /* Uso da variável delegado para a análise semântica */
-            $$ = new_var($1);
+            $$ = set_node_line(new_var($1), @1.first_line);
         }
 
     | STRING_LITERAL
         {
             if (debug_mode) printf("String processada: %s\n", $1);
-            $$ = new_string_literal($1);
+            $$ = set_node_line(new_string_literal($1), @1.first_line);
         }
 
     | CHAR_LITERAL
         {
             if (debug_mode) printf("Char processado: %s\n", $1);
-            $$ = new_char_literal($1);
+            $$ = set_node_line(new_char_literal($1), @1.first_line);
         }
     
     | NUMFLOAT
         {
-            $$ = new_num($1);
+            $$ = set_node_line(new_num($1), @1.first_line);
         }
     
     | MINUS expr %prec UMINUS
         {
-            $$ = new_binop(
+            $$ = set_node_line(new_binop(
                     OP_SUB,
-                    new_num(0),
+                    set_node_line(new_num(0), @1.first_line),
                     $2
-                );
+                ), @1.first_line);
         }
     
     | error
@@ -315,7 +317,7 @@ expr
 
             yyerrok;
 
-            $$ = new_num(0);
+            $$ = set_node_line(new_num(0), yylineno);
         }
     ;
 

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6,6 +6,11 @@
 #include "parser.tab.h"  /* contém definições geradas pelo Bison (NUM, PLUS, etc.) */
 
 int lexical_errors = 0;
+
+#define YY_USER_ACTION do { \
+    yylloc.first_line = yylineno; \
+    yylloc.last_line = yylineno; \
+} while (0);
 %}
 
 %option yylineno noinput nounput
@@ -33,7 +38,7 @@ auto          { return AUTO_TYPE_INFERENCE; }
 bool          { return BOOL_TYPE; }
 break         { return DECLARATION; }
 case          { return KW_SWITCH; }
-char          { return TYPE_SPECIFIER; }
+char          { yylval.str = strdup(yytext); return TYPE_SPECIFIER; }
 const         { return CONST_LITERAL; }
 constexpr     { return SPECIFIER; }
 continue      { return CONTINUE_STATEMENT; }
@@ -44,13 +49,13 @@ else          { return ELSE_STATEMENT; }
 enum          { return ENUMERATION_TYPE; }
 extern        { return STORAGE_CLASS_SPECIFIER; }
 false         { return FALSE_LITERAL; }
-float         { return TYPE_SPECIFIER; }
+float         { yylval.str = strdup(yytext); return TYPE_SPECIFIER; }
 for           { return LOOP; }
-fortran       { return TYPE_SPECIFIER; }
+fortran       { yylval.str = strdup(yytext); return TYPE_SPECIFIER; }
 goto          { return STATEMENT; }
 if            { return IF_STATEMENT; }
 inline        { return INLINE_FUNCTION_SPECIFIER; }
-int           { return TYPE_SPECIFIER; }
+int           { yylval.str = strdup(yytext); return TYPE_SPECIFIER; }
 long          { return KW_LONG; }
 nullptr       { return POINTER_CONSTANT; }
 register      { return AUTOMATIC_DURATION_STORAGE_CLASS_SPECIFIER; }
@@ -61,7 +66,7 @@ signed        { return KW_SIZE; }
 sizeof        { return OPERATOR; }
 static        { return KW_STATIC; }
 static_assert { return STATIC_ASSERT_DECLARATION; }
-str           { return TYPE_SPECIFIER; }
+str           { yylval.str = strdup(yytext); return TYPE_SPECIFIER; }
 struct        { return KW_DECLARATION_OF_A_COMPOUND_TYPE; }
 switch        { return SWITCH_STATEMENT; }
 thread_local  { return KW_THREAD_STORAGE_CLASS_SPECIFIER; }

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -1,7 +1,26 @@
 #include <stdio.h>
-#include <stdlib.h>
 #include "semantic.h"
 #include "symtab.h"
+
+static int node_line(ASTNode *node) {
+    return (node && node->line > 0) ? node->line : 0;
+}
+
+static int semantic_error_undeclared(const char *name, int line) {
+    fprintf(stderr,
+            "Erro semantico na linha %d: variavel '%s' nao declarada.\n",
+            line,
+            name);
+    return 1;
+}
+
+static int semantic_error_redeclared(const char *name, int line) {
+    fprintf(stderr,
+            "Erro semantico na linha %d: variavel '%s' ja declarada neste escopo.\n",
+            line,
+            name);
+    return 1;
+}
 
 int analyze_ast(ASTNode *node) {
     if (!node) return 0;
@@ -9,48 +28,47 @@ int analyze_ast(ASTNode *node) {
     int errors = 0;
 
     switch (node->type) {
-        
         case NODE_NUM:
         case NODE_STRING:
         case NODE_CHAR:
-            // Nós lógicos de literais não geram erros semânticos isolados
             break;
 
         case NODE_VAR: {
-            // Verifica se a variável que está sendo usada já foi declarada/definida
-            const Symbol *sym = symtab_lookup(node->var_name);
+            const Symbol *sym = symtab_lookup_visible(node->var_name, SYMTAB_GLOBAL_SCOPE);
             if (!sym) {
-                fprintf(stderr, "Erro semantico: variavel '%s' usada mas nao foi declarada.\n", node->var_name);
-                errors++;
+                errors += semantic_error_undeclared(node->var_name, node_line(node));
             } else {
-                // Registra o uso na tabela de símbolos
-                // Usamos 0 temporariamente porque a estrutura atual da AST não guarda a linha do nó
-                symtab_use(node->var_name, 0); 
+                symtab_use(node->var_name, node_line(node));
             }
             break;
         }
 
         case NODE_ASSIGN: {
-            // 1. Primeiro analisa o valor que está sendo atribuído (pode ser uma expressão complexa ou outra variável)
-            if (node->assign.value) {
-                errors += analyze_ast(node->assign.value);
+            if (node->assign.is_declaration) {
+                if (!symtab_insert(node->assign.name,
+                                   node->assign.decl_type,
+                                   SYMTAB_GLOBAL_SCOPE,
+                                   node_line(node))) {
+                    errors += semantic_error_redeclared(node->assign.name, node_line(node));
+                }
+
+                if (node->assign.value) {
+                    errors += analyze_ast(node->assign.value);
+                }
+                break;
             }
 
-            // 2. Agora analisa a variável que está recebendo o valor
-            const Symbol *sym = symtab_lookup(node->assign.name);
-            
-            // Se a variável não existe na tabela, interpretamos este NODE_ASSIGN como a primeira declaração dela
-            if (!sym) {
-                symtab_define(node->assign.name, 0);
-            } else {
-                // Se já existe, apenas registramos uma nova atribuição/atualização na tabela
-                symtab_define(node->assign.name, 0);
+            if (!symtab_lookup_visible(node->assign.name, SYMTAB_GLOBAL_SCOPE)) {
+                errors += semantic_error_undeclared(node->assign.name, node_line(node));
+            }
+
+            if (node->assign.value) {
+                errors += analyze_ast(node->assign.value);
             }
             break;
         }
 
         case NODE_BINOP:
-            // Garante que ambos os lados da operação matemática/lógica são semânticamente válidos
             errors += analyze_ast(node->binop.left);
             errors += analyze_ast(node->binop.right);
             break;
@@ -58,9 +76,7 @@ int analyze_ast(ASTNode *node) {
         case NODE_IF:
             errors += analyze_ast(node->if_node.cond);
             errors += analyze_ast(node->if_node.then_branch);
-            if (node->if_node.else_branch) {
-                errors += analyze_ast(node->if_node.else_branch);
-            }
+            errors += analyze_ast(node->if_node.else_branch);
             break;
 
         case NODE_WHILE:
@@ -69,7 +85,6 @@ int analyze_ast(ASTNode *node) {
             break;
 
         case NODE_BLOCK:
-            // Percorre o comando atual do bloco e depois avança para os próximos comandos
             errors += analyze_ast(node->block.statement);
             errors += analyze_ast(node->block.next);
             break;

--- a/src/semantic.h
+++ b/src/semantic.h
@@ -8,4 +8,3 @@
 int analyze_ast(ASTNode *node);
 
 #endif
-#define SEMANTIC_H

--- a/src/symtab.c
+++ b/src/symtab.c
@@ -7,10 +7,11 @@
 
 static Symbol *symtab_head = NULL;
 
-static Symbol *symtab_find(const char *name) {
+static Symbol *symtab_find_in_scope_mut(const char *name, int scope) {
     Symbol *cur = symtab_head;
+
     while (cur) {
-        if (strcmp(cur->name, name) == 0) {
+        if (cur->scope == scope && strcmp(cur->name, name) == 0) {
             return cur;
         }
         cur = cur->next;
@@ -19,164 +20,181 @@ static Symbol *symtab_find(const char *name) {
     return NULL;
 }
 
+static Symbol *symtab_find_visible_mut(const char *name, int scope) {
+    Symbol *global = NULL;
+    Symbol *cur = symtab_head;
+
+    while (cur) {
+        if (strcmp(cur->name, name) == 0) {
+            if (cur->scope == scope) {
+                return cur;
+            }
+            if (cur->scope == SYMTAB_GLOBAL_SCOPE) {
+                global = cur;
+            }
+        }
+        cur = cur->next;
+    }
+
+    return global;
+}
+
+static Symbol *symtab_new_symbol(const char *name, const char *type, int scope, int line) {
+    Symbol *sym = (Symbol *)malloc(sizeof(Symbol));
+    if (!sym) {
+        perror("malloc failed");
+        exit(1);
+    }
+
+    sym->name = strdup(name);
+    if (!sym->name) {
+        perror("strdup failed");
+        exit(1);
+    }
+
+    sym->type = strdup(type ? type : "unknown");
+    if (!sym->type) {
+        perror("strdup failed");
+        exit(1);
+    }
+
+    sym->scope = scope;
+    sym->defined_line = line;
+    sym->last_used_line = line;
+    sym->use_count = 0;
+    sym->assign_count = 0;
+    sym->val_type = VAL_NONE;
+    sym->num_val = 0.0;
+    sym->str_val = NULL;
+    sym->next = NULL;
+
+    return sym;
+}
+
 void symtab_init(void) {
     symtab_head = NULL;
 }
 
-const Symbol *symtab_lookup(const char *name) {
-    return symtab_find(name);
-}
-
-void symtab_set_value_num(const char *name, double val) {
-    Symbol *sym = symtab_find(name);
-    if (sym) {
-        if (sym->str_val) {
-            free(sym->str_val);
-            sym->str_val = NULL;
-        }
-        sym->val_type = VAL_NUM;
-        sym->num_val = val;
+int symtab_insert(const char *name, const char *type, int scope, int line) {
+    if (symtab_find_in_scope_mut(name, scope)) {
+        return 0;
     }
+
+    Symbol *sym = symtab_new_symbol(name, type, scope, line);
+    sym->next = symtab_head;
+    symtab_head = sym;
+    return 1;
 }
 
-void symtab_set_value_str(const char *name, const char *str) {
-    Symbol *sym = symtab_find(name);
-    if (sym) {
-        if (sym->str_val) {
+const Symbol *symtab_lookup_in_scope(const char *name, int scope) {
+    return symtab_find_in_scope_mut(name, scope);
+}
+
+const Symbol *symtab_lookup_visible(const char *name, int scope) {
+    return symtab_find_visible_mut(name, scope);
+}
+
+const Symbol *symtab_lookup(const char *name) {
+    return symtab_lookup_visible(name, SYMTAB_GLOBAL_SCOPE);
+}
+
+void symtab_remove_scope(int scope) {
+    Symbol **cur = &symtab_head;
+
+    while (*cur) {
+        Symbol *sym = *cur;
+        if (sym->scope == scope) {
+            *cur = sym->next;
+            free(sym->name);
+            free(sym->type);
             free(sym->str_val);
-            sym->str_val = NULL;
-        }
-        sym->val_type = VAL_STR;
-        if (str) {
-            sym->str_val = strdup(str);
+            free(sym);
+        } else {
+            cur = &sym->next;
         }
     }
 }
 
 void symtab_define(const char *name, int line) {
-    Symbol *sym = symtab_find(name);
+    Symbol *sym = symtab_find_visible_mut(name, SYMTAB_GLOBAL_SCOPE);
 
     if (!sym) {
-        sym = (Symbol *)malloc(sizeof(Symbol));
-        if (!sym) {
-            perror("malloc failed");
-            exit(1);
-        }
-
-        sym->name = strdup(name);
-        if (!sym->name) {
-            perror("strdup failed");
-            exit(1);
-        }
-
-        sym->defined_line = line;
-        sym->last_used_line = line;
-        sym->use_count = 0;
-        sym->assign_count = 1;
-        sym->val_type = VAL_NONE;
-        sym->num_val = 0.0;
-        sym->str_val = NULL;
-        sym->next = symtab_head;
-        symtab_head = sym;
+        symtab_insert(name, "unknown", SYMTAB_GLOBAL_SCOPE, line);
         return;
     }
 
     if (sym->defined_line < 0) {
         sym->defined_line = line;
     }
-
     sym->last_used_line = line;
+}
+
+void symtab_set_value_num(const char *name, double val) {
+    Symbol *sym = symtab_find_visible_mut(name, SYMTAB_GLOBAL_SCOPE);
+    if (!sym) {
+        return;
+    }
+
+    free(sym->str_val);
+    sym->str_val = NULL;
+    sym->val_type = VAL_NUM;
+    sym->num_val = val;
+    sym->assign_count += 1;
+}
+
+void symtab_set_value_str(const char *name, const char *str) {
+    Symbol *sym = symtab_find_visible_mut(name, SYMTAB_GLOBAL_SCOPE);
+    if (!sym) {
+        return;
+    }
+
+    free(sym->str_val);
+    sym->str_val = NULL;
+    sym->val_type = VAL_STR;
+    sym->str_val = strdup(str ? str : "");
+    if (!sym->str_val) {
+        perror("strdup failed");
+        exit(1);
+    }
     sym->assign_count += 1;
 }
 
 void symtab_assign(const char *name, struct ASTNode *val, int line) {
-    Symbol *sym = symtab_find(name);
-
+    Symbol *sym = symtab_find_visible_mut(name, SYMTAB_GLOBAL_SCOPE);
     if (!sym) {
-        sym = (Symbol *)malloc(sizeof(Symbol));
-        if (!sym) {
-            perror("malloc failed");
-            exit(1);
-        }
-
-        sym->name = strdup(name);
-        if (!sym->name) {
-            perror("strdup failed");
-            exit(1);
-        }
-
-        sym->defined_line = line;
-        sym->last_used_line = line;
-        sym->use_count = 0;
-        sym->assign_count = 1;
-        sym->val_type = VAL_NONE;
-        sym->num_val = 0.0;
-        sym->str_val = NULL;
-        sym->next = symtab_head;
-        symtab_head = sym;
-    } else {
-        if (sym->defined_line < 0) sym->defined_line = line;
-        sym->last_used_line = line;
-        sym->assign_count += 1;
+        return;
     }
 
+    if (sym->defined_line < 0) {
+        sym->defined_line = line;
+    }
+    sym->last_used_line = line;
+
     if (!val) {
-        /* no value provided */
-        if (sym->str_val) {
-            free(sym->str_val);
-            sym->str_val = NULL;
-        }
+        free(sym->str_val);
+        sym->str_val = NULL;
         sym->val_type = VAL_NONE;
         return;
     }
 
     switch (val->type) {
         case NODE_NUM:
-            if (sym->str_val) { free(sym->str_val); sym->str_val = NULL; }
-            sym->val_type = VAL_NUM;
-            sym->num_val = val->num_val;
+            symtab_set_value_num(name, val->num_val);
             break;
 
         case NODE_STRING:
         case NODE_CHAR:
-            if (sym->str_val) free(sym->str_val);
-            sym->val_type = VAL_STR;
-            sym->str_val = strdup(val->str_val ? val->str_val : "");
+            symtab_set_value_str(name, val->str_val ? val->str_val : "");
             break;
 
         default:
-            /* complex expression — we don't evaluate here */
             break;
     }
 }
 
 void symtab_use(const char *name, int line) {
-    Symbol *sym = symtab_find(name);
-
+    Symbol *sym = symtab_find_visible_mut(name, SYMTAB_GLOBAL_SCOPE);
     if (!sym) {
-        sym = (Symbol *)malloc(sizeof(Symbol));
-        if (!sym) {
-            perror("malloc failed");
-            exit(1);
-        }
-
-        sym->name = strdup(name);
-        if (!sym->name) {
-            perror("strdup failed");
-            exit(1);
-        }
-
-        sym->defined_line = -1;
-        sym->last_used_line = line;
-        sym->use_count = 1;
-        sym->assign_count = 0;
-        sym->next = symtab_head;
-        symtab_head = sym;
-
-        fprintf(stderr,
-                "Aviso semantico: variavel '%s' usada antes de ser atribuida (linha %d)\n",
-                name,
-                line);
         return;
     }
 
@@ -188,8 +206,10 @@ void symtab_dump(void) {
     Symbol *cur = symtab_head;
 
     printf("\n--- Tabela de Simbolos ---\n");
-    printf("%-20s %-12s %-12s %-8s %-8s %-12s\n",
+    printf("%-20s %-12s %-8s %-12s %-12s %-8s %-8s %-12s\n",
            "Nome",
+           "Tipo",
+           "Escopo",
            "LinhaDef",
            "LinhaUso",
            "Usos",
@@ -206,8 +226,10 @@ void symtab_dump(void) {
             snprintf(valbuf, sizeof(valbuf), "-");
         }
 
-        printf("%-20s %-12d %-12d %-8d %-8d %-12s\n",
+        printf("%-20s %-12s %-8d %-12d %-12d %-8d %-8d %-12s\n",
                cur->name,
+               cur->type ? cur->type : "-",
+               cur->scope,
                cur->defined_line,
                cur->last_used_line,
                cur->use_count,
@@ -219,10 +241,12 @@ void symtab_dump(void) {
 
 void symtab_free(void) {
     Symbol *cur = symtab_head;
+
     while (cur) {
         Symbol *next = cur->next;
         free(cur->name);
-        if (cur->str_val) free(cur->str_val);
+        free(cur->type);
+        free(cur->str_val);
         free(cur);
         cur = next;
     }

--- a/src/symtab.h
+++ b/src/symtab.h
@@ -3,8 +3,12 @@
 
 typedef struct ASTNode ASTNode;
 
+#define SYMTAB_GLOBAL_SCOPE 0
+
 typedef struct Symbol {
     char *name;
+    char *type;
+    int scope;
     int defined_line;
     int last_used_line;
     int use_count;
@@ -21,6 +25,10 @@ typedef struct Symbol {
 } Symbol;
 
 void symtab_init(void);
+int symtab_insert(const char *name, const char *type, int scope, int line);
+const Symbol *symtab_lookup_in_scope(const char *name, int scope);
+const Symbol *symtab_lookup_visible(const char *name, int scope);
+void symtab_remove_scope(int scope);
 void symtab_define(const char *name, int line);
 void symtab_assign(const char *name, ASTNode *val, int line);
 void symtab_use(const char *name, int line);

--- a/src/tests/atribuicao/sobrescrita.txt
+++ b/src/tests/atribuicao/sobrescrita.txt
@@ -1,5 +1,5 @@
 // Atribuir valores diferentes para a mesma variável e ler várias vezes
 int louis = 2;
 louis;
-int louis = 20;
+louis = 20;
 louis;


### PR DESCRIPTION
Implementei a tabela de símbolos e a verificação semântica.
Arquivos alterados:
src/ast.h
src/parser.y
src/scanner.l
src/symtab.h
src/semantic.h
src/tests/atribuicao/sobrescrita.txt

O projeto já tinha NODE_ASSIGN e NODE_VAR. Mantive esses nós: declarações agora são NODE_ASSIGN com is_declaration, decl_type e line. O parser cria declaração com new_declaration(...); atribuição normal segue com new_assign(...). O scanner agora preenche localização via YY_USER_ACTION, e o parser usa %locations para guardar a linha nos nós da AST.
A tabela agora guarda nome, tipo, escopo e metadados já existentes de uso/valor. A análise semântica percorre a AST depois do parse: declarações chamam symtab_insert; redeclaração no mesmo escopo gera erro; atribuições e usos de NODE_VAR consultam a tabela antes de aceitar.

Verificado:
Build pelo WSL: cd src && make
Suíte: cd src && ./run_tests.sh
Resultado: Total de testes com falha/timeout: 0

Casos pedidos testados manualmente: válido passa; x = 10;, redeclaração e y = x + 1; emitem erro semântico com linha e nome.

Limitação atual: a estrutura está preparada para escopos, inclusive com symtab_remove_scope, mas a análise usa SYMTAB_GLOBAL_SCOPE. O parser hoje transforma { stmt_list } no próprio stmt_list, sem preservar um nó de bloco com fronteira de escopo, então escopos aninhados ainda não são diferenciados.